### PR TITLE
build: workflow for PyPI publishing done

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# ENV FILE CAN BE LOADED BY UV WHEN RUNNING COMMANDS (`uv run ...`)
+# For that, either:
+# - define environment variable UV_ENV_FILE to $PWD/.env (eg. with direnv)
+# - provide --env-file <path/to/.env> to uv run
+
+# Used to publish to test.pypi.org from local environment:
+UV_PUBLISH_URL=https://test.pypi.org/legacy/
+UV_PUBLISH_TOKEN=...

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -65,7 +65,7 @@ jobs:
 
   deploy:
     environment:
-      name: github-pages
+      name: main
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,34 @@
+name: pypi-publish
+
+on:
+  push:
+    branches: ["main","test"]
+
+concurrency:
+  group: "pypi-publish"
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_name }}
+    steps:
+    - name: echo-vars
+      run: >
+        echo "Github environment: ${{ github.ref_name }}"
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        version: "0.5.24"
+    - name: Build Python Package
+      run: uv build
+    - name: Deploy Python Package
+      run: uv publish
+      env:
+        UV_PUBLISH_URL: ${{ vars.UV_PUBLISH_URL }}
+        UV_PUBLISH_CHECK_URL: ${{ vars.UV_PUBLISH_CHECK_URL }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,8 +1,7 @@
-name: pytest-action
-run-name: PYTEST
+name: unit-tests
 on: [push]
 jobs:
-  run-pytest:
+  pytest-and-coverage:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -235,16 +235,25 @@ More info : https://pre-commit.com/
 
 ## Github CI/CD
 
-**Main branch protection rule:**
+### Unit tests / Coverage
+`unit-tests` workflow is triggered on every push, regardless of the branch.
+
+### Main branch
+**Protection rules:**  
 - Require a pull request before merging
-- Require pytest tests to pass before merge
+- Require unit tests to pass before merging
 
-**Documentation build/deployment:**
-- github action `gh-pages` is setup to build and deploy documentation
-- deployment is done in `github-pages` environment, only allowed for the main branch
+**Workflows:**  
+Commits on the main branch triggers:
+- `gh-pages` workflow that builds and deploys documentation
+- `pypi-publish` workflow that builds and publish package to pypi.org (trusted publisher)
 
-**Tests:**
-- github action `pytest-action` is setup to run pytest on each push
+### Test branch
+**Protection rules:**  
+- Require the pushed commits to have passed unit tests before pushing, either:
+  - merge a compliant branch to test 
+  - push the commit to another branch first and then force push the branch to test (`git push -f origin <src_branch>:test`)
 
-**PyPI Publishment:**
-- **TODO** : auto deploy to PyPI
+**Workflows:**  
+Commits on the test branch triggers:
+- `pypi-publish` workflow that builds and publish package to test.pypi.org (trusted publisher)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xfp"
-version = "1.0.0"
+version = "1.1.0-b1"
 description = "functional programming library for python"
 authors = [
     { name = "Sébastien VEY" },

--- a/uv.lock
+++ b/uv.lock
@@ -479,15 +479,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.392.post0"
+version = "1.1.393"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/df/3c6f6b08fba7ccf49b114dfc4bb33e25c299883fd763f93fad47ef8bc58d/pyright-1.1.392.post0.tar.gz", hash = "sha256:3b7f88de74a28dcfa90c7d90c782b6569a48c2be5f9d4add38472bdaac247ebd", size = 3789911 }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/c1/aede6c74e664ab103673e4f1b7fd3d058fef32276be5c43572f4067d4a8e/pyright-1.1.393.tar.gz", hash = "sha256:aeeb7ff4e0364775ef416a80111613f91a05c8e01e58ecfefc370ca0db7aed9c", size = 3790430 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/b1/a18de17f40e4f61ca58856b9ef9b0febf74ff88978c3f7776f910071f567/pyright-1.1.392.post0-py3-none-any.whl", hash = "sha256:252f84458a46fa2f0fd4e2f91fc74f50b9ca52c757062e93f6c250c0d8329eb2", size = 5595487 },
+    { url = "https://files.pythonhosted.org/packages/92/47/f0dd0f8afce13d92e406421ecac6df0990daee84335fc36717678577d3e0/pyright-1.1.393-py3-none-any.whl", hash = "sha256:8320629bb7a44ca90944ba599390162bf59307f3d9fb6e27da3b7011b8c17ae5", size = 5646057 },
 ]
 
 [[package]]
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "xfp"
-version = "1.0.0"
+version = "1.1.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "deprecation" },


### PR DESCRIPTION
Now based on two Github environments:
- main: that targets pypi.org + gh pages
- test: that targets test.pypi.org

`pypi-publish` workflow created, depending on the branch:
  - if `main` -> uses main environment
  - if `test` -> uses test environment

previous `pytest-action` workflow renamed to `unit-tests` (it's not an action, it's a workflow...)

README updated with relevant description