### PR TITLE
Xlist, fold methods with standard syntax

### DIFF
--- a/tests/xlist/test_xlist_methods.py
+++ b/tests/xlist/test_xlist_methods.py
@@ -128,7 +128,31 @@ def test_xlist_max() -> None:
 
 def test_xlist_fold() -> None:
     input = Xlist(["b", "c"])
+    actual = input.fold("a", lambda acc, el: acc + el)
+    expected = "abc"
+
+    assert actual == expected
+
+
+def test_xlist_fold_curried() -> None:
+    input = Xlist(["b", "c"])
     actual = input.fold("a")(lambda acc, el: acc + el)
+    expected = "abc"
+
+    assert actual == expected
+
+
+def test_xlist_fold_left() -> None:
+    input = Xlist(["b", "c"])
+    actual = input.fold("a", lambda acc, el: acc + el)
+    expected = "abc"
+
+    assert actual == expected
+
+
+def test_xlist_fold_left_curried() -> None:
+    input = Xlist(["b", "c"])
+    actual = input.fold_left("a")(lambda acc, el: acc + el)
     expected = "abc"
 
     assert actual == expected
@@ -136,8 +160,16 @@ def test_xlist_fold() -> None:
 
 def test_xlist_fold_right() -> None:
     input = Xlist(["c", "b"])
+    actual = input.fold_right("a", lambda el, acc: acc + el)
+    expected = "cba"
+
+    assert actual == expected
+
+
+def test_xlist_fold_right_curried() -> None:
+    input = Xlist(["c", "b"])
     actual = input.fold_right("a")(lambda el, acc: acc + el)
-    expected = "abc"
+    expected = "cba"
 
     assert actual == expected
 


### PR DESCRIPTION
Xlist:
- fixed: bug on fold_right
- added: method can be used with standard syntax. Curried syntax deprecated

No way to deprecate typing overload signature. Deprecations are only 'processed' on real code -> deprecation manually put on docstring + deprecation warning in the function that applies the fold methods when using curried syntax