### PR TITLE
unit-tests workflow ignored on main test

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,9 @@
 name: unit-tests
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main
+      - test
 jobs:
   pytest-and-coverage:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
No need to redo unit-tests when merging/pushing on main or test branches. These branches are protected, the pushed commit must have passed the unit-tests workflow.